### PR TITLE
20 additional CI checks (pre-commit)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier",
+    // "prettier",
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,16 +15,6 @@ module.exports = {
     "ecmaFeatures": {
       "jsx": true,
     },
-    "extends": [
-      "eslint:recommended",
-      "plugin:react/recommended",
-      "plugin:@typescript-eslint/recommended",
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "ecmaFeatures": {
-        "jsx": true,
-      },
       "ecmaVersion": 13,
       "sourceType": "module",
     },
@@ -48,6 +38,5 @@ module.exports = {
       "react/jsx-key": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
       "react/jsx-no-target-blank": "off",
-    },
   },
 };

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@
   rev: v8.3.0
   hooks:
   - id: eslint
+    additional_dependencies: ['eslint@8.3.0','eslint-plugin-react','@typescript-eslint/eslint-plugin', 'typescript','typescript-eslint', '@typescript-eslint/parser']
     files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
     types: [file]
 - repo: https://github.com/Yelp/detect-secrets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,17 +13,12 @@
 - repo: https://github.com/pre-commit/mirrors-eslint
   rev: v8.3.0
   hooks:
-    - id: eslint
-      files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
-      types: [file]
-# - repo: https://github.com/pre-commit/mirrors-prettier
-#   rev: v2.5.0
-#   hooks:
-#     - id: prettier
-- repo: git@github.com:Yelp/detect-secrets
+  - id: eslint
+    files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
+    types: [file]
+- repo: https://github.com/Yelp/detect-secrets
   rev: v1.1.0
   hooks:
     - id: detect-secrets
       args: ["--baseline", ".secrets.baseline"]
       exclude: .*/tests/.*
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/button-inc/digital_marketplace/main.svg)](https://results.pre-commit.ci/latest/github/button-inc/digital_marketplace/main)
 # Digital Marketplace
 
 The Digital Marketplace is a web application that administers British Columbia's Code With Us and Sprint With Us procurement programs. It enables (1) public sector employees to create and publish procurement opportunities, and (2) vendors to submit proposals to these opportunities.


### PR DESCRIPTION
The pre-commit github action is deprecated, so we're using https://pre-commit.ci/, which is set up through the pre-commit ci website (it's not a github action). It runs on pull requests and then automatically commits its changes when possible. (If you run pre-commit locally before pushing, you'll never see the auto-commits because everything will already be clean.)

This PR:
- adds the pre-commit badge to the readme
- tweaks the `.pre-commit-config.yaml` to accommodate pre-commit ci (adds some dependencies and temporarily comments out prettier)
- fixes duplication in the `.pre-commit-config.yaml`