### PR TITLE
Adjust eslint for future integration with prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,27 +1,36 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true,
     },
     "extends": [
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/recommended"
+      "eslint:recommended",
+      "plugin:react/recommended",
+      "plugin:@typescript-eslint/recommended",
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": 13,
-        "sourceType": "module"
+      "ecmaFeatures": {
+        "jsx": true,
+      },
+      "ecmaVersion": 13,
+      "sourceType": "module",
     },
-    "plugins": [
-        "react",
-        "@typescript-eslint"
-    ],
+    "plugins": ["react", "@typescript-eslint"],
     "rules": {
-        # TODO remove rule overrides that affect code quality
+      // TODO remove rule overrides that affect code quality
       "@typescript-eslint/no-explicit-any": "off",
       "react/prop-types": "off",
       "@typescript-eslint/no-unused-vars": "off",
@@ -38,6 +47,7 @@ module.exports = {
       "no-duplicate-case": "off",
       "react/jsx-key": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
-      "react/jsx-no-target-blank": "off"
-      }
+      "react/jsx-no-target-blank": "off",
+    },
+  },
 };

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,14 +10,18 @@
     - id: end-of-file-fixer
     - id: trailing-whitespace
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.3.0  # Use the sha / tag you want to point at
+  rev: v8.3.0
   hooks:
-  - id: eslint
-    files: \.[jt]sx?$  # *.js, *.jsx, *.ts and *.tsx
-    types: [file]
+    - id: eslint
+      files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
+      types: [file]
+# - repo: https://github.com/pre-commit/mirrors-prettier
+#   rev: v2.5.0
+#   hooks:
+#     - id: prettier
 - repo: git@github.com:Yelp/detect-secrets
   rev: v1.1.0
   hooks:
-  - id: detect-secrets
-    args: ['--baseline', '.secrets.baseline']
-    exclude: .*/tests/.*
+    - id: detect-secrets
+      args: ["--baseline", ".secrets.baseline"]
+      exclude: .*/tests/.*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Ignore artifacts
+build
+node_modules


### PR DESCRIPTION
ref #27

As a developer, in the future I want to integrate prettier formatting into the Digital Marketplace, so that we can have consistently formatted, readable code.

DoD:

- Extend prettier in `eslintrc.js`, this allows eslint and prettier to play nice together
- Add commented out entry to `pre-commit-config.yaml` that will be uncommented at a later date to allow `pre-commit` to scan staged files.
- Create `.prettierignore` file to include dirs and files that are ignored by `prettier`