### PR TITLE
Add commit linting to pre-commit; switch pre-commit to a github action

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,5 @@ module.exports = {
       "@typescript-eslint/ban-types": "off",
       "react/no-children-prop": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
-      "react/jsx-no-target-blank": "off",
-      "no-empty-description": "off"
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,5 +35,7 @@ module.exports = {
       "@typescript-eslint/ban-types": "off",
       "react/no-children-prop": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
+      "react/jsx-no-target-blank": "off",
+      "no-empty-description": "off"
   },
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,10 @@ jobs:
       - run: npm ci
       - run: npm run front-end:build
       - run: npm run back-end:build
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,10 @@ jobs:
       - uses: actions/setup-node@v2
       - run: pip install pre-commit
       - run: pre-commit run --all-files
+  commitlint:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,8 @@
     - id: detect-secrets
       args: ["--baseline", ".secrets.baseline"]
       exclude: .*/tests/.*
+- repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+  rev: v2.2.0
+  hooks:
+      - id: commitlint
+        stages: [commit-msg]

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']}

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -7,8 +7,9 @@
   - see docs [Click](https://pre-commit.com/#install)
 
 - Setup
-  - run `pre-commit install` to set up the git hook script
-  - see docs [Click](https://pre-commit.com/#install)
+  - run `pre-commit install` to set up the git hook script ([see docs](https://pre-commit.com/#install))
+  - run `pre-commit install --hook-type commit-msg` to set up the commitlint hook ([see docs](https://github.com/alessandrojcm/commitlint-pre-commit-hook))
+
 
 ### Things to keep in mind regarding the git authoring lifecycle (HEAD, Staged, Unstaged) and pre-commit hooks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18363,6 +18363,15 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@commitlint/config-conventional": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-15.0.0.tgz",
+      "integrity": "sha512-eZBRL8Lk3hMNHp1wUMYj0qrZQEsST1ai7KHR8J1IDD9aHgT7L2giciibuQ+Og7vxVhR5WtYDvh9xirXFVPaSkQ==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-conventionalcommits": "^4.3.1"
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.19",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.19.tgz",
@@ -19786,6 +19795,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+      "dev": true
     },
     "array-includes": {
       "version": "3.1.4",
@@ -21320,6 +21335,16 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
       "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
     },
+    "compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "requires": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -21476,6 +21501,17 @@
       "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
       "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
       "dev": true
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
+      "integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
+        "q": "^1.5.1"
+      }
     },
     "convert-hrtime": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "yargs": "^16.0.3"
   },
   "devDependencies": {
+    "@commitlint/config-conventional": "^15.0.0",
     "@types/cors": "^2.8.7",
     "@types/html-to-text": "^1.4.31",
     "@types/keycloak-connect": "^4.5.1",


### PR DESCRIPTION
This PR:

- addresses https://github.com/button-inc/digital_marketplace/issues/45 (replaces https://github.com/button-inc/digital_marketplace/pull/54)
- puts pre-commit in the CI github action (I'll turn off pre-commit ci once this is merged in; it's a setting, not code)
- adds commitlint to the CI github action
- adds a commitlint config file
- updates docs with instructions for using commitlint locally

Note: commitlint doesn't seem to have a way to check authors' emails