### PR TITLE
Fix react/no children prop eslint error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,6 @@ module.exports = {
       "@typescript-eslint/no-var-requires": "off",
       "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/ban-types": "off",
-      "react/no-children-prop": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
   },
 };

--- a/src/front-end/typescript/lib/app/view/nav.tsx
+++ b/src/front-end/typescript/lib/app/view/nav.tsx
@@ -280,18 +280,22 @@ interface TitleProps extends Pick<Props, 'title' | 'homeDest'> {
   color?: ThemeColor;
 }
 
-const Title: View<TitleProps> = ({ title, homeDest, dispatch, color = 'c-nav-fg', className = '' }) => (
-  <div className={`nav-title ${className}`}>
-    <NavLink
-      dispatch={dispatch}
-      children={title}
-      focusable={false}
-      color={color}
-      dest={homeDest}
-      style={{ pointerEvents: homeDest ? undefined : 'none' }}
-      className='font-weight-bolder font-size-large' />
-  </div>
-);
+const Title: View<TitleProps> = function({ title, homeDest, dispatch, color = 'c-nav-fg', className = '' }) {
+  console.log('title is:',title)
+  console.log('typof title is:', typeof title)
+  return (
+    <div className={`nav-title ${className}`}>
+      <NavLink
+        dispatch={dispatch}
+        children={title}
+        focusable={false}
+        color={color}
+        dest={homeDest}
+        style={{ pointerEvents: homeDest ? undefined : 'none' }}
+        className='font-weight-bolder font-size-large' />
+    </div>
+  );
+}
 
 const MobileMenu: View<Props> = props => {
   const isMobileMenuOpen = props.state.isMobileMenuOpen;

--- a/src/front-end/typescript/lib/views/markdown.tsx
+++ b/src/front-end/typescript/lib/views/markdown.tsx
@@ -65,7 +65,9 @@ const Markdown: View<Props> = ({ source, box, className = '', escapeHtml = true,
           return (<img {...props} src={decodeImgSrc(props.src || '')} />);
         },
     heading: smallerHeadings
-      ? ({ level, children }: any) => { //React-Markdown types are not helpful here.
+      ? function({ level, children }: any) { //React-Markdown types are not helpful here.
+        console.log('children are',children)
+        console.log('typeof children are:',typeof children)
           return (<div className={`${headingLevelToClassName(level)} text-secondary`} children={children} />);
         }
       : ReactMarkdown.renderers.heading


### PR DESCRIPTION
I found this one tricky to understand, here are the docs I found in case they're helpful:
- eslint docs: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md
- https://stackoverflow.com/questions/42982416/why-shouldnt-children-be-passed-as-a-prop

As far I can tell, this error arises because the Base Props interface has a prop named "children":
```
interface BaseProps {
  tag?: 'a' | 'div';
  dest?: Dest;
  symbol_?: Placement<LinkSymbol>;
  symbolClassName?: string;
  symbolStyle?: CSSProperties;
  iconSymbolSize?: number; //rem
  children?: ViewElementChildren;
  className?: string;
  style?: CSSProperties;
  disabled?: boolean;
  newTab?: boolean;
  focusable?: boolean;
  onClick?(e?: MouseEvent): void;
}
```
BaseProps is used all over the place, as is the word "children," so I think it would be time-consuming to fix this one. When I tried changing "children" in BaseProps to a different word, I got 400 lines of TS errors.
