### PR TITLE
Fix @typescript eslint/ban types estlint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,6 @@ module.exports = {
       "react/prop-types": "off",
       "@typescript-eslint/no-var-requires": "off",
       "@typescript-eslint/no-empty-function": "off",
-      "@typescript-eslint/ban-types": "off",
       "react/no-children-prop": "off",
   },
   overrides: [

--- a/src/back-end/lib/routers/admin/index.tsx
+++ b/src/back-end/lib/routers/admin/index.tsx
@@ -43,7 +43,7 @@ const NotificationGroup: View<NotificationGroupProps> = ({ title, emails }) => {
   );
 };
 
-async function makeEmailNotificationReference(): Promise<View<{}>> {
+async function makeEmailNotificationReference(): Promise<View<Record<string, never>>> {
   const notifications: NotificationGroupProps[] = [
     {
       title: 'Account Registered',

--- a/src/front-end/typescript/lib/app/view/footer.tsx
+++ b/src/front-end/typescript/lib/app/view/footer.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { Col, Container, Row } from 'reactstrap';
 import { CONTACT_EMAIL, COPY } from 'shared/config';
 import { adt } from 'shared/lib/types';
-import { string } from 'yargs';
 
 const links: AnchorProps[] = [
   {

--- a/src/front-end/typescript/lib/app/view/footer.tsx
+++ b/src/front-end/typescript/lib/app/view/footer.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { Col, Container, Row } from 'reactstrap';
 import { CONTACT_EMAIL, COPY } from 'shared/config';
 import { adt } from 'shared/lib/types';
+import { string } from 'yargs';
 
 const links: AnchorProps[] = [
   {
@@ -50,7 +51,7 @@ const links: AnchorProps[] = [
   }
 ];
 
-const Footer: View<{}> = () => {
+const Footer: View<Record<string, never>> = () => {
   return (
     <footer className='w-100 bg-c-footer-bg text-light d-print-none'>
       <Container>

--- a/src/front-end/typescript/lib/components/form-field/date.tsx
+++ b/src/front-end/typescript/lib/components/form-field/date.tsx
@@ -63,7 +63,7 @@ type ChildParams = FormField.ChildParamsBase<Value> & Pick<ChildState, 'min' | '
 type InnerChildMsg
   = ADT<'onChange', Value>;
 
-type ExtraChildProps = {};
+type ExtraChildProps = Record<string, unknown>;
 
 type ChildComponent = FormField.ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>;
 

--- a/src/front-end/typescript/lib/components/form-field/index.tsx
+++ b/src/front-end/typescript/lib/components/form-field/index.tsx
@@ -30,7 +30,7 @@ export interface ChildProps<Value, ChildState extends ChildStateBase<Value>, Inn
   onChange: OnChange<Value>;
 }
 
-export type ChildComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = {}> = framework.Component<ChildParams, ChildState, ChildMsg<InnerChildMsg>, ChildProps<Value, ChildState, InnerChildMsg> & ExtraChildProps>;
+export type ChildComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = unknown> = framework.Component<ChildParams, ChildState, ChildMsg<InnerChildMsg>, ChildProps<Value, ChildState, InnerChildMsg> & ExtraChildProps>;
 
 export type Validate<Value> = (value: Value) => Validation<Value>;
 

--- a/src/front-end/typescript/lib/components/form-field/index.tsx
+++ b/src/front-end/typescript/lib/components/form-field/index.tsx
@@ -30,7 +30,7 @@ export interface ChildProps<Value, ChildState extends ChildStateBase<Value>, Inn
   onChange: OnChange<Value>;
 }
 
-export type ChildComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = {}> = framework.Component<ChildParams, ChildState, ChildMsg<InnerChildMsg>, ChildProps<Value, ChildState, InnerChildMsg> & ExtraChildProps>;
+export type ChildComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = Record<string, never>> = framework.Component<ChildParams, ChildState, ChildMsg<InnerChildMsg>, ChildProps<Value, ChildState, InnerChildMsg> & ExtraChildProps>;
 
 export type Validate<Value> = (value: Value) => Validation<Value>;
 
@@ -52,7 +52,7 @@ export type Msg<InnerChildMsg>
   | ADT<'validate'>
   | ADT<'child', ChildMsg<InnerChildMsg>>;
 
-export interface ViewProps<Value, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = {}> extends ComponentViewProps<State<Value, ChildState>, Msg<InnerChildMsg>> {
+export interface ViewProps<Value, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = Record<string, never>> extends ComponentViewProps<State<Value, ChildState>, Msg<InnerChildMsg>> {
   extraChildProps: ExtraChildProps;
   className?: string;
   labelClassName?: string;
@@ -69,7 +69,7 @@ export interface ViewProps<Value, ChildState extends ChildStateBase<Value>, Inne
   };
 }
 
-export type Component<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = {}> = framework.Component<Params<Value, ChildParams>, State<Value, ChildState>, Msg<InnerChildMsg>, ViewProps<Value, ChildState, InnerChildMsg, ExtraChildProps>>;
+export type Component<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = Record<string, never>> = framework.Component<Params<Value, ChildParams>, State<Value, ChildState>, Msg<InnerChildMsg>, ViewProps<Value, ChildState, InnerChildMsg, ExtraChildProps>>;
 
 function makeInit<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps>(childInit: ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>['init']): Component<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>['init'] {
   return async params => ({
@@ -132,7 +132,7 @@ function ConditionalHelpToggle<Value, ChildState extends ChildStateBase<Value>, 
   }
 }
 
-export const ViewRequiredAsterisk: View<{}> = () => {
+export const ViewRequiredAsterisk: View<Record<string, never>> = () => {
   return (<span className='font-weight-bold text-c-form-field-required ml-1'>*</span>);
 };
 
@@ -227,7 +227,7 @@ function makeView<Value, ChildParams extends ChildParamsBase<Value>, ChildState 
   };
 }
 
-export function makeComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = {}>(params: ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>): Component<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps> {
+export function makeComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = Record<string, never>>(params: ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>): Component<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps> {
   return {
     init: makeInit(params.init),
     update: makeUpdate(params.update),

--- a/src/front-end/typescript/lib/components/form-field/index.tsx
+++ b/src/front-end/typescript/lib/components/form-field/index.tsx
@@ -30,7 +30,7 @@ export interface ChildProps<Value, ChildState extends ChildStateBase<Value>, Inn
   onChange: OnChange<Value>;
 }
 
-export type ChildComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = Record<string, never>> = framework.Component<ChildParams, ChildState, ChildMsg<InnerChildMsg>, ChildProps<Value, ChildState, InnerChildMsg> & ExtraChildProps>;
+export type ChildComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = {}> = framework.Component<ChildParams, ChildState, ChildMsg<InnerChildMsg>, ChildProps<Value, ChildState, InnerChildMsg> & ExtraChildProps>;
 
 export type Validate<Value> = (value: Value) => Validation<Value>;
 
@@ -52,7 +52,7 @@ export type Msg<InnerChildMsg>
   | ADT<'validate'>
   | ADT<'child', ChildMsg<InnerChildMsg>>;
 
-export interface ViewProps<Value, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = Record<string, never>> extends ComponentViewProps<State<Value, ChildState>, Msg<InnerChildMsg>> {
+export interface ViewProps<Value, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = unknown> extends ComponentViewProps<State<Value, ChildState>, Msg<InnerChildMsg>> {
   extraChildProps: ExtraChildProps;
   className?: string;
   labelClassName?: string;
@@ -69,7 +69,7 @@ export interface ViewProps<Value, ChildState extends ChildStateBase<Value>, Inne
   };
 }
 
-export type Component<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = Record<string, never>> = framework.Component<Params<Value, ChildParams>, State<Value, ChildState>, Msg<InnerChildMsg>, ViewProps<Value, ChildState, InnerChildMsg, ExtraChildProps>>;
+export type Component<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = unknown> = framework.Component<Params<Value, ChildParams>, State<Value, ChildState>, Msg<InnerChildMsg>, ViewProps<Value, ChildState, InnerChildMsg, ExtraChildProps>>;
 
 function makeInit<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps>(childInit: ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>['init']): Component<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>['init'] {
   return async params => ({
@@ -227,7 +227,7 @@ function makeView<Value, ChildParams extends ChildParamsBase<Value>, ChildState 
   };
 }
 
-export function makeComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = Record<string, never>>(params: ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>): Component<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps> {
+export function makeComponent<Value, ChildParams extends ChildParamsBase<Value>, ChildState extends ChildStateBase<Value>, InnerChildMsg, ExtraChildProps = unknown>(params: ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>): Component<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps> {
   return {
     init: makeInit(params.init),
     update: makeUpdate(params.update),

--- a/src/front-end/typescript/lib/components/form-field/short-text-multi.tsx
+++ b/src/front-end/typescript/lib/components/form-field/short-text-multi.tsx
@@ -16,7 +16,7 @@ type InnerChildMsg
   | ADT<'add', { onChange: FormField.OnChange<Value>; }>
   | ADT<'remove', { index: number; onChange: FormField.OnChange<Value>; }>;
 
-type ExtraChildProps = {};
+type ExtraChildProps = Record<string, never>;
 
 type ChildComponent = FormField.ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>;
 

--- a/src/front-end/typescript/lib/components/form-field/short-text-multi.tsx
+++ b/src/front-end/typescript/lib/components/form-field/short-text-multi.tsx
@@ -16,7 +16,7 @@ type InnerChildMsg
   | ADT<'add', { onChange: FormField.OnChange<Value>; }>
   | ADT<'remove', { index: number; onChange: FormField.OnChange<Value>; }>;
 
-type ExtraChildProps = Record<string, never>;
+type ExtraChildProps = Record<string, unknown>;
 
 type ChildComponent = FormField.ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>;
 

--- a/src/front-end/typescript/lib/components/form-field/time.tsx
+++ b/src/front-end/typescript/lib/components/form-field/time.tsx
@@ -29,7 +29,7 @@ type ChildParams = FormField.ChildParamsBase<Value> & Pick<ChildState, 'min' | '
 type InnerChildMsg
   = ADT<'onChange', Value>;
 
-type ExtraChildProps = {};
+type ExtraChildProps = Record<string, unknown>;
 
 type ChildComponent = FormField.ChildComponent<Value, ChildParams, ChildState, InnerChildMsg, ExtraChildProps>;
 

--- a/src/front-end/typescript/lib/framework/index.tsx
+++ b/src/front-end/typescript/lib/framework/index.tsx
@@ -49,7 +49,7 @@ export type ViewElement<Props = any> = null | ReactElement<Props>;
 
 export type ViewElementChildren<Props = any> = ViewElement<Props> | string | Array<ReactElement<Props> | null | string>;
 
-export type View<Props = {}, ReturnValue = ViewElement> = (props: Props) => ReturnValue;
+export type View<Props = Record<string, never>, ReturnValue = ViewElement> = (props: Props) => ReturnValue;
 
 export interface ComponentViewProps<State, Msg> {
   state: Immutable<State>;


### PR DESCRIPTION
This PR:

- turns on the @typescript eslint/ban types rule
- fixes the @typescript eslint/ban types eslint lint errors
- partially addresses Fixing eslint rule errors Fixing eslint rule errors Fixing eslint rule errors Fixing eslint rule errors #37

Note: I tried to changing the ones in `form-field/index.ts` to both the `Record` suggestions (example screenshot below) but I got errors both times, so I went with `unknown`. 
![Screenshot from 2021-12-08 16-37-06](https://user-images.githubusercontent.com/77306764/145313384-9c8b45c3-f081-4587-901e-b6277e73e1a3.png)
