### PR TITLE
fix: add -v flag to pre-commit command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
       - run: pip install pre-commit
-      - run: pre-commit run --all-files
+      - run: pre-commit run --all-files -v
   commitlint:
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
This PR adds the [-v flag](https://pre-commit.com/#:~:text=-v%2C%20--verbose%3A%20produce%20hook%20output%20independent%20of%20success.%20Include%20hook%20ids%20in%20output.) to the pre-commit command that's running in CI. Without this flag, pre-commit will fix errors in the CI's copy of the code (NOT in our repo) instead of failing the job.