### PR TITLE
Fix typescript eslint no var requires eslint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,4 +36,13 @@ module.exports = {
       "react/no-children-prop": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
   },
+  overrides: [
+    {
+      // enable the rule specifically for TypeScript files
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "@typescript-eslint/no-var-requires": "error"
+      }
+    }
+  ]
 };


### PR DESCRIPTION
This PR:
- Adds an override to the eslint config file to restrict this rule's application to ts/tsx files only
- Partially addresses #25 

Note: Some conversation/docs on this here: https://github.com/typescript-eslint/typescript-eslint/issues/1724#:~:text=Our%20rules%20intentionally%20do%20not%20distinguish%20between%20JS%20and%20TS%20files%20(for%20a%20number%20of%20reasons) and https://github.com/typescript-eslint/typescript-eslint/blob/v5.5.0/packages/eslint-plugin/docs/rules/no-var-requires.md