### PR TITLE
Turn on eslint rules that warn

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,13 +28,10 @@ module.exports = {
         // TODO remove rule overrides that affect code quality
       "@typescript-eslint/no-explicit-any": "off",
       "react/prop-types": "off",
-      "@typescript-eslint/no-unused-vars": "off",
-      "no-case-declarations": "off",
       "@typescript-eslint/no-var-requires": "off",
       "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/ban-types": "off",
       "react/no-children-prop": "off",
-      "@typescript-eslint/no-non-null-assertion": "off",
   },
   overrides: [
     {


### PR DESCRIPTION
This PR:
- turns on eslint rules that give warnings (code should continue to pass CI)
- partially addresses #25
- [no-non-null-assertion](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-non-null-assertion.md)--the ones that throw this error include a `!`, so it looks like the original authors expected null sometimes. New ticket for this tech debt: #86
- [no-unused-vars](https://github.com/typescript-eslint/typescript-eslint/blob/v5.5.0/packages/eslint-plugin/docs/rules/no-unused-vars.md)--many warnings. New ticket for this tech debt: #87
- no-case-declarations--errors fixed through previous work on #25 