### PR TITLE
docs: update PR template to use github keywords

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,9 @@
 This PR closes #
 
-Includes tests? [Y/N]
-Rebased on main address to conflicts? [Y/N]
-Updated docs? [Y/N]
+- [ ] Includes tests?
+- [ ] Rebased on main address to conflicts?
+- [ ] Updated docs?
+- [ ] No console logs or unnecessary comments?
 
 Proposed changes:
 -

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-This PR addresses issue: [issue #]
+This PR closes #
 
 Includes tests? [Y/N]
 Rebased on main address to conflicts? [Y/N]


### PR DESCRIPTION
This PR addresses issue: n/a

Includes tests? n/a
Rebased on main address to conflicts? n/a
Updated docs? y

Proposed changes:
- update the PR template to use github keywords so issues and PRs will be automatically linked, notably on zenhub
- add checkboxes and another check for console logs/commented out code

Additional notes:
- docs on keywords here: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue